### PR TITLE
Edit some basic documentation to match OWP template -- updates will continue

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,10 @@
-MIT License
+APACHE 2.0 LICENSE
+-----------------
+Software code created by U.S. Government employees is not subject to copyright in the United States (17 U.S.C. §105). The United States/Department of Commerce reserve all rights to seek and obtain copyright protection in countries other than the United States for Software authored in its entirety by the Department of Commerce. To this end, the Department of Commerce hereby grants to Recipient a royalty-free, nonexclusive license to use, copy, and create derivative works of the Software outside of the United States
+------------------
+Contains code from [topoflow36](https://github.com/peckhams/topoflow36)
 
-Copyright (c) 2019 Scott D. Peckham
+Copyright (C) 2019 by Scott D. Peckham
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,13 +13,13 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,75 @@
-# topoflow36
-TopoFlow version 3.6 is an update to version 3.5 that runs in Python 3.7 and contains over 98,000 lines of Python code.
-TopoFlow 3.5 is in the "topoflow" repository and runs in Python 2.7. (Over 75,000 lines of code.)
+# TopoFlow
 
-The best way to learn about TopoFlow --- including its history, capabilities, input data preparation and an example application --- is to read the paper in the "docs" folder called:  "Peckham_et_al_2017_GPF.pdf", along with its appendices "Peckham_et_al_2017_GPF_Appendices.pdf".  One of the appendices explains how to install the Python package and run a test.  It is convenient to first install the Anaconda Python distribution, create a conda environment like "tf36", and then install the netCDF4 package dependency in that environment.
+**Description**:  
+TopoFlow provides a plug-and-play, component-based modeling framework for spatial hydrologic modeling.  Both use the EMELI framework to couple a set of user-selected components into a functioning model.  The EMELI framework is included in the topoflow "framework" folder. [A paper on EMELI](https://github.com/NOAA-OWP/topoflow/blob/master/docs/Peckham_2014_EMELI_FINAL.pdf) is included in the "docs" folder.
 
-Detailed information on each TopoFlow model component --- including its variables and the equations used --- can be found on the CSDMS wiki website at:  https://csdms.colorado.edu/wiki/Model:TopoFlow.  Each component has its own very detailed HTML Help Page.  Links to these can be found near the bottom of the main CSDMS page for TopoFlow.  For example, the HTML Help Page for the TopoFlow Meteorology component can be found here:  https://csdms.colorado.edu/wiki/Model_help:TopoFlow-Meteorology.  One of the components is actually a self-contained, fluvial landscape evolution model (LEM) called Erode.
+TopoFlow was adapted to model combined snow and ice melt contributions to streamflow in glaciated catchments as part of NextGen modeling efforts, but TopoFlow also provides several other modules related to channel routing, potential evapotranspiration and infiltration estimates, and more. 
 
-TopoFlow versions 3.5 and 3.6 each provide a plug-and-play, component-based modeling framework for spatial hydrologic modeling.  Both use the EMELI framework to couple a set of user-selected components into a functioning model.  The EMELI framework is included in the topoflow "framework" folder.  A paper on EMELI is included in the "docs" folder, called:  "Peckham_2014_EMELI_FINAL.pdf".  Another paper in that folder, "Jiang_et_al_2018.pdf", describes EMELI-Web, a version of EMELI that couples and runs a set of TopoFlow components all running as web services on different servers.  
-
-Model components are in the topoflow "components" folder and each have a Basic Model Interface (BMI).  Details on BMI can be found here:  https://csdms.colorado.edu/wiki/BMI_Description.  They all inherit from BMI_base.py in the "utils" folder.  Each model component has its own configuration file, a text file with extension ".cfg".  Components may get their input data from other components in a component set (passed by reference), or directly from input files.  By editing model CFG files, users specify which output variables are to be saved to files (and at what "sampling timestep) and values of variables are then written to netCDF files (and optionally to some other file formats).
+Model components are in the topoflow "components" folder and each have a Basic Model Interface (BMI).  Details on BMI can be found here:  https://csdms.colorado.edu/wiki/BMI_Description.  They all inherit from BMI_base.py in the "utils" folder.  Each model component has its own configuration file, a text file with extension ".cfg".  Components may get their input data from other components in a component set (passed by reference), or directly from input files.  By editing model CFG files, users specify which output variables are to be saved to files (and at what "sampling timestep) and values of variables are then written to netCDF files (and optionally to some other file formats). 
+Detailed information on each TopoFlow model component --- including its variables and the equations used --- can be found on the CSDMS wiki website at:  https://csdms.colorado.edu/wiki/Model:TopoFlow.  
 
 The "utils" folder has a large collection of utilities that are used to create and read input files, write output files and provide other low-level functionality to all components.  It also includes a complete toolkit for computing a D8 flow direction grid and all related variables (like slope and total contributing area) from a DEM.  The "examples" folder contains several data sets for testing, including the Treynor watershed in Iowa with input data for two historic rainfall events both from June 1967.  Included in these examples are folders showing correct output files that can be used for testing.
 
+  - **Technology stack**: TopoFlow that runs in Python 3.7 or later and contains over 98,000 lines of Python code. The model can be run either in standalone or as part of the [NextGen Framework](https://github.com/NOAA-OWP/ngen). 
+  - **Status**:  TopoFlow is currently able to run in standalone. TopoFlow has been run in the NextGen Framework, but a standarization process and associated documentation for users is currently in development. 
+
+## Dependencies
+
+TopoFlow requires a Python version of 3.7 or later. The latest version of Python the model has been tested with is 3.9.
+
+## Installation
+
+Detailed instructions on how to install TopoFlow can be found at [INSTALL](INSTALL.md).
+
+## Configuration
+
+If the software is configurable, describe it in detail, either here or in other documentation to which you link.
+
+## Usage
+
+Show users how to use the software.
+Be specific.
+Use appropriate formatting when showing code snippets.
+
+## How to test the software
+
+If the software includes automated tests, detail how to run those tests.
+
+## Known issues
+
+Document any known significant shortcomings with the software.
+
+## Getting help
+
+Instruct users how to get help with this software; this might include links to an issue tracker, wiki, mailing list, etc.
+
+**Example**
+
+If you have questions, concerns, bug reports, etc, please file an issue in this repository's Issue Tracker.
+
+## Getting involved
+
+This section should detail why people should get involved and describe key areas you are
+currently focusing on; e.g., trying to get feedback on features, fixing certain bugs, building
+important pieces, etc.
+
+General instructions on _how_ to contribute should be stated with a link to [CONTRIBUTING](CONTRIBUTING.md).
+
+
+----
+
+## Open source licensing info
+1. [TERMS](TERMS.md)
+2. [LICENSE](LICENSE)
+
+
+----
+
+## Credits and references
+
+1. Related projects:
+
 CSDMS (csdms.colorado.edu) uses an older version of TopoFlow and also provides a graphical user interface via its Web Modeling Tool.  See:  https://csdms.colorado.edu/wiki/CSDMS_Web_Modeling_Tool  (and https://csdms.colorado.edu/wiki/HydrologyExecutorBlanca).  Incomplete efforts to create a wizard-style GUI for TopoFlow in Python --- similar to the GUI used in the old IDL version of TopoFlow 1.6b --- can be found in the "gui_old" folder.
+2. Books, papers, talks, or other sources that have meaningful impact or influence on this project:
+
+The best way to learn about TopoFlow --- including its history, capabilities, input data preparation and an example application --- is to read the paper [Peckham et al. (2017)](https://github.com/NOAA-OWP/topoflow/blob/master/docs/Peckham_et_al_2017_GPF.pdf) in the "docs" folder, along with its [appendices](https://github.com/NOAA-OWP/topoflow/blob/master/docs/Peckham_et_al_2017_GPF_Appendices.pdf).  One of the appendices explains how to install the Python package and run a test.  It is convenient to first install the Anaconda Python distribution, create a conda environment like "tf36", and then install the netCDF4 package dependency in that environment.


### PR DESCRIPTION
Reworked info from the original topoflow36 repo's README into the OWP README format. 

Changed the LICENSE to keep Scott's copyright but also outline the OWP licensing info. 

Will commit additional changes soon with detailed INSTALL info, pointers to test cases in the README, etc. 